### PR TITLE
A little improvement of U.S. English translation

### DIFF
--- a/src/main/resources/assets/invtweaks/lang/en_us.json
+++ b/src/main/resources/assets/invtweaks/lang/en_us.json
@@ -2,5 +2,5 @@
   "key.categories.invtweaks": "Inventory Tweaks Renewed",
   "key.invtweaks_sort_player.desc": "Sort Player Inventory",
   "key.invtweaks_sort_inventory.desc": "Sort External Inventory",
-  "key.invtweaks_sort_either.desc": "Sort Inventory under Mouse"
+  "key.invtweaks_sort_either.desc": "Sort Inventory Under Cursor"
 }


### PR DESCRIPTION
I changed word "mouse" to "cursor", as the latter is used more often, and is much less misleading.