### PR TITLE
Fixed sorting fail and crash for 1.16.1

### DIFF
--- a/src/main/java/invtweaks/util/Sorting.java
+++ b/src/main/java/invtweaks/util/Sorting.java
@@ -355,7 +355,7 @@ public class Sorting {
             destinationSlot=destinationIter.previous();
 
             // If the stack is not at max capacity AND can stack with the one that is held right now
-            if (destinationSlot.getStack().getCount()!=destinationSlot.getStack().getMaxStackSize()
+            if (destinationSlot.getStack().getCount()!=Math.min(destinationSlot.getSlotStackLimit(),destinationSlot.getStack().getMaxStackSize())
                 && Utils.STACKABLE.equivalent(destinationSlot.getStack(),player.inventory.getItemStack())) {
               // Stay on this current 'previous' slot (by doing nothing).
             }

--- a/src/main/java/invtweaks/util/Sorting.java
+++ b/src/main/java/invtweaks/util/Sorting.java
@@ -236,7 +236,6 @@ public class Sorting {
                         toModify.remove(displacedPair.getKey());
                         toModify.add(displacedPair.getValue());
                       }
-                      toIt.next();
                     }
                   });
         } else {
@@ -311,14 +310,7 @@ public class Sorting {
           }
           // System.out.println(gatheredSlots.get(stackW).size());
           // System.out.println("HAS_PREV: "+fromIt.hasPrevious());
-          if (!fullInserted) fromIt.previous();
-          while (fromIt.hasPrevious()) {
-            fromIt.previous();
-            fromIt.remove();
-          }
           // System.out.println(gatheredSlots.get(stackW).size());
-          if (!toIt.hasNext()) break;
-          toIt.next();
         }
       }
       stackWs.removeIf(sw -> gatheredSlots.get(sw).isEmpty());
@@ -351,6 +343,14 @@ public class Sorting {
         pc.windowClick(player.openContainer.windowId, slot.slotNumber, 0, ClickType.PICKUP, player);
         Slot toSlot = null;
         while (to.hasNext()) {
+          // if prev exists, isn't a full stack, and is stackable, we will try to place our stack there instead.
+          if (to.hasPrevious())
+          {
+            toSlot=to.previous();
+            if (toSlot.getStack().getMaxStackSize()==toSlot.getStack().getCount()
+                || !Utils.STACKABLE.equivalent(toSlot.getStack(),player.inventory.getItemStack()))
+              to.next();
+          }
           toSlot = to.next();
           pc.windowClick(
               player.openContainer.windowId, toSlot.slotNumber, 0, ClickType.PICKUP, player);
@@ -358,6 +358,9 @@ public class Sorting {
             didCompleteCurrent = true;
             break;
           }
+          // If its overflow from the current item, no need to swap it back to the starting position, just try the next slot.
+          if (Utils.STACKABLE.equivalent(toSlot.getStack(),player.inventory.getItemStack()))
+            continue;
           pc.windowClick(
               player.openContainer.windowId, slot.slotNumber, 0, ClickType.PICKUP, player);
           if (slot.getHasStack()
@@ -376,7 +379,6 @@ public class Sorting {
                 .isPresent()) {
           break;
         }
-        to.previous();
       }
       return didCompleteCurrent;
     }


### PR DESCRIPTION
The important changes are in the first of the three commits. See its description for more info.
The second commit formats+refactors+comments clientPushToSlots.
The third commit changes one line for checking a slot's max stack size, which I forgot in the first commit.