### PR TITLE
(Partial) fix for Tinker's Crafting Station sorting

### DIFF
--- a/src/main/java/invtweaks/config/InvTweaksConfig.java
+++ b/src/main/java/invtweaks/config/InvTweaksConfig.java
@@ -79,6 +79,7 @@ public class InvTweaksConfig {
                     .put("appeng.container.implementations.PatternTermContainer", new ContOverride(NO_POS_OVERRIDE, NO_POS_OVERRIDE, ""))
                     .put("appeng.container.implementations.WirelessTermContainer", new ContOverride(NO_POS_OVERRIDE, NO_POS_OVERRIDE, ""))
                     .put("net.blay09.mods.excompressum.container.AutoSieveContainer", new ContOverride(NO_POS_OVERRIDE, NO_POS_OVERRIDE, ""))
+                    .put("slimeknights.tconstruct.tables.inventory.table.CraftingStationContainer", new ContOverride(NO_POS_OVERRIED, NO_POS_OVERRIDE, ""))
 
                     .build();
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7953513/130872040-4d1bb0a3-49b7-4a14-821e-33d505495bb0.png)

After:
![image](https://user-images.githubusercontent.com/7953513/130872051-bdee2105-f787-4814-b430-8f3b06af6c08.png)

The other button is actually from the chest - I'm not sure if/how it can be removed.