### PR TITLE
Prevent sorting in Force Furnace

### DIFF
--- a/src/main/java/invtweaks/config/InvTweaksConfig.java
+++ b/src/main/java/invtweaks/config/InvTweaksConfig.java
@@ -79,6 +79,7 @@ public class InvTweaksConfig {
                     .put("appeng.container.implementations.PatternTermContainer", new ContOverride(NO_POS_OVERRIDE, NO_POS_OVERRIDE, ""))
                     .put("appeng.container.implementations.WirelessTermContainer", new ContOverride(NO_POS_OVERRIDE, NO_POS_OVERRIDE, ""))
                     .put("net.blay09.mods.excompressum.container.AutoSieveContainer", new ContOverride(NO_POS_OVERRIDE, NO_POS_OVERRIDE, ""))
+                    .put("com.mrbysco.forcecraft.container.furnace.ForceFurnaceContainer", new ContOverride(NO_POS_OVERRIDE, NO_POS_OVERRIDE, ""))
 
                     .build();
 


### PR DESCRIPTION
Fixes being able to take out the upgrade by sorting the furnace which you shouldn't be able to take out without voiding it